### PR TITLE
Add support to audit the translated strings

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -253,6 +253,15 @@ function load_en_file() {
 		}catch (error){
 			alert("The json file contain an error. \n" + error );
 		}
+    function addKey(obj, key, value) {
+      Object.values(obj).forEach(val => {
+        if (val && typeof val === 'object') addKey(val, key, value);
+      });
+      if (!obj[key]) {
+        obj[key] = value;
+      }
+    }
+    addKey(en_json, "audited", false);
 		saved_json = en_json;
 		let new_html = populateHTML(en_json, "");
 		document.getElementsByTagName("main")[0].innerHTML = new_html;

--- a/javascript.js
+++ b/javascript.js
@@ -173,7 +173,6 @@ function isVisible(e) {
 
 function collapse_all_translated(){
 	var spans = document.querySelectorAll("span.collapse_button");
-  console.log("spans",spans);
   spans.forEach(span => {
     if(!span.nextSibling.classList.contains("needs_translation") && !span.nextSibling.classList.contains("collapsed")){
       span.nextSibling.classList.add("collapsed");

--- a/javascript.js
+++ b/javascript.js
@@ -222,7 +222,12 @@ function load_en_file() {
 
 	string_counter = 0;
 	function populateHTML(json_table, json_key_in_input_id) {
-		var txt = "<ul>";
+    var txt = null;
+    if(json_table["audited"]){
+      txt = "<ul class='collapsed'>";
+    } else {
+      txt = "<ul>";
+    }
 		for (key in json_table) {
 			var current_key = json_key_in_input_id+"."+key;
 			if(typeof json_table[key] === 'string'){

--- a/javascript.js
+++ b/javascript.js
@@ -152,8 +152,15 @@ function changed_all_input_text(){
 }
 
 function collapse(arrow){
-	arrow.nextSibling.classList.toggle("collapsed");
-	arrow.classList.toggle("change_arrow");
+  let spans = arrow.parentNode.querySelectorAll("span.collapse_button");
+  let parentCheckbox = spans[0].children[0].checked;
+  spans.forEach(span => {
+    if(span == spans[0] || (!parentCheckbox && !span.children[0].checked)){
+      span.nextSibling.classList.toggle("collapsed");
+      span.classList.toggle("change_arrow");
+      update_json_file(span.children[0]);
+    }
+  });
 }
 
 function reset_input_file(input_file_element){
@@ -165,13 +172,15 @@ function isVisible(e) {
 }
 
 function collapse_all_translated(){
-	var uls = document.querySelectorAll('ul');
-	for(i = 0; i < uls.length; i++) {
-		if ( isVisible(uls[i]) && !uls[i].classList.contains('needs_translation') ){
-			uls[i].classList.add("collapsed");
-			uls[i].previousSibling.classList.toggle("change_arrow");
-		}
-	}
+	var spans = document.querySelectorAll("span.collapse_button");
+  console.log("spans",spans);
+  spans.forEach(span => {
+    if(!span.nextSibling.classList.contains("needs_translation") && !span.nextSibling.classList.contains("collapsed")){
+      span.nextSibling.classList.add("collapsed");
+      span.classList.add("change_arrow");
+      update_json_file(span.children[0]);
+    }
+  });
 }
 
 function goto_next_unstranslated(){

--- a/javascript.js
+++ b/javascript.js
@@ -242,9 +242,15 @@ function load_en_file() {
 				txt += "<div class='translate'>";
 				txt += json_table[key].replace(/</g,'&lt;')+"</div>";
 				txt+="</li>";
-			}
+			}else if(typeof json_table[key] === 'boolean'){
+        // do nothing, since we don't want to show the audited key as a span
+      }
 			else{
-				txt += "<li><span class='collapse_button' onclick='collapse(this)'>"+key+"</span>";
+				if(json_table[key]["audited"]){
+          txt += "<li><span class='collapse_button change_arrow' onclick='collapse(this)' id='" + current_key.replace('.', '') + "'>" + key + " - audited translation" + "<input type='checkbox' value='audited' disabled checked='"+json_table[key]["audited"]+"'>" + "</span>";
+        } else {
+          txt += "<li><span class='collapse_button' onclick='collapse(this)' id='" + current_key.replace('.', '') + "'>" + key + " - audited translation" + "<input type='checkbox' value='audited' disabled>" + "</span>";
+        }
 				txt += populateHTML(json_table[key], current_key);
 				txt += "</li>";
 			}

--- a/javascript.js
+++ b/javascript.js
@@ -54,14 +54,24 @@ function merge(first_json, second_json){
 
 function update_json_file(this_input){
 	function update_json_key(old_json, path){
-		let current_level = path.shift();
+    let target_level = path.slice(-1)[0];
+    let current_level = path.shift();
 		if(typeof old_json[current_level] === 'string'){
 			old_json[current_level] = this_input.value;
-		}else{
+		}else if(this_input.value == "audited" && target_level == current_level){
+      let audited = !this_input.checked;
+      this_input.checked = audited;
+      old_json[current_level]["audited"] = this_input.checked;
+    }else{
 			update_json_key(old_json[current_level], path);
 		}
 	}
-	let path = this_input.previousSibling.id;
+	let path = null;
+  if(this_input.value == "audited"){
+    path = this_input.parentNode.id;
+  }else{
+    path = this_input.previousSibling.id;
+  }
 	update_json_key(saved_json, path.split("."));
 }
 


### PR DESCRIPTION
Is difficult to keep track of all the strings that have been already audited on the file, specially when you leave the work for a while and come back just to realize that you forgot to bookmark where you left it off, these changes are to solve this kind of issue.

- Add `audited` `key-value` pair when loading the first `JSON`, since the functionality between the first and the second file is a merge between those.
- Change the `innerHtml` insertion tags to support the newly added pair functionalities.
- Change logic to update the `JSON` file so that it can handle the current logic and the newly added to support the pair value change.
- Fix some issues with the `collapse` funcions, seems that they where not behaving as intended from a further review in the code, this also came with the added support for the pair, so a `win-win` situation I guess :V.